### PR TITLE
fixed home section scrolling, removed episode play btn scaling (it wa…

### DIFF
--- a/complete/finity-complete.css
+++ b/complete/finity-complete.css
@@ -717,7 +717,7 @@ div.detailPageContent div.detailSectionContent p, /* General paragraph in detail
   right: -42px;
 }
 
-.material-icons.play_arrow:before { /* Icon itself */
+.material-icons.play_arrow::before { /* Icon itself */
   margin-left: 10px;
 }
 
@@ -1127,6 +1127,10 @@ div.listItem-content div.listItemImage.listItemImage-large.itemAction.lazy.non-b
   left: -5.5px;
 }
 
+.material-icons.listItemImageButton-icon.play_arrow::before {
+  margin-left: 0;
+}
+
 /* ======================================== */
 /* === RESPONSIVE ADJUSTMENTS === */
 /* ======================================== */
@@ -1315,9 +1319,6 @@ option {
   .cardOverlayContainer > .cardOverlayFab-primary {
     font-size: 100%;
   }
-  .paper-icon-button-light:hover:not(:disabled) {
-    transform: scale(0.7) !important;
-  }
 }
 
 /* restore position for ribbon */
@@ -1377,14 +1378,14 @@ html.layout-desktop [dir="rtl"] .detailRibbon {
 /* Adjust the scroll buttons container's spacing */
 .layout-desktop .moreFromSeasonSection .emby-scrollbuttons {
 	padding-right: 0 !important;
+  margin-right: 0 !important;
 	flex-shrink: 0;
-	left: 12vw;
 	display: inline-table;
 	top: 1.35vw;
 }
 
 .emby-scrollbuttons {
-  margin-right: 80vw !important;
+  margin-right: 0 !important;
 }
 
 /* --- Home Section Container Positioning --- */

--- a/minimal/finity-minimal.css
+++ b/minimal/finity-minimal.css
@@ -725,7 +725,7 @@ div.detailPageContent div.detailSectionContent p, /* General paragraph in detail
   right: -42px;
 }
 
-.material-icons.play_arrow:before { /* Icon itself */
+.material-icons.play_arrow::before { /* Icon itself */
   margin-left: 10px;
 }
 
@@ -1135,6 +1135,10 @@ div.listItem-content div.listItemImage.listItemImage-large.itemAction.lazy.non-b
   left: -5.5px;
 }
 
+.material-icons.listItemImageButton-icon.play_arrow::before {
+  margin-left: 0;
+}
+
 /* ======================================== */
 /* === RESPONSIVE ADJUSTMENTS === */
 /* ======================================== */
@@ -1365,14 +1369,14 @@ html.layout-desktop [dir="rtl"] .detailRibbon {
 /* Adjust the scroll buttons container's spacing */
 .layout-desktop .moreFromSeasonSection .emby-scrollbuttons {
 	padding-right: 0 !important;
+  margin-right: 0 !important;
 	flex-shrink: 0;
-	left: 12vw;
 	display: inline-table;
 	top: 1.35vw;
 }
 
 .emby-scrollbuttons {
-  margin-right: 80vw !important;
+  margin-right: 0 !important;
 }
 
 /* --- Home Section Container Positioning --- */
@@ -1395,9 +1399,6 @@ html.layout-desktop [dir="rtl"] .detailRibbon {
   }
   .cardOverlayContainer > .cardOverlayFab-primary {
     font-size: 100%;
-  }
-  .paper-icon-button-light:hover:not(:disabled) {
-    transform: scale(0.7) !important;
   }
 }
 


### PR DESCRIPTION
## Description
Jellyfin  v10.11.8
### Home
-  Section scrolling buttons are overlapping the section title.
<img width="536" height="78" alt="image" src="https://github.com/user-attachments/assets/cfbd2e78-32f8-4ae9-b0ed-88bad39b9d43" />

### Seasons' Episodes List
- Seasons' Episode Play button moves away from cursor when trying to play
- Seasons' Episode Play button has a small offset from center
<img width="259" height="271" alt="image" src="https://github.com/user-attachments/assets/4495e958-8fc0-41b8-9076-d8f26b0f0884" />
<img width="261" height="266" alt="image" src="https://github.com/user-attachments/assets/e370ad92-44f3-485d-b843-157860679f2d" />

## Fix

- Changed home section's scrolling to avoid overlap with section Titles, now on right
- Changed Margins for Episode Play material icon to center it
- Removed episode play btn transform transition, now matches other play btn behaviors

<img width="1214" height="50" alt="image" src="https://github.com/user-attachments/assets/91bd2851-a493-4194-9ce3-054448e4b63b" />
<img width="275" height="277" alt="image" src="https://github.com/user-attachments/assets/dce33bb6-717c-45d5-9a36-4108f0d94fed" />

